### PR TITLE
Control FEMPO sync with traspassat flag

### DIFF
--- a/src/main/java/cat/politecnicllevant/gestsuitegestordocumental/service/DocumentService.java
+++ b/src/main/java/cat/politecnicllevant/gestsuitegestordocumental/service/DocumentService.java
@@ -77,6 +77,13 @@ public class DocumentService {
         return document != null;
     }
 
+    public boolean isDocumentTraspassat(String nom, ConvocatoriaDto convocatoria) {
+        Convocatoria convocatoriaEntity = modelMapper.map(convocatoria, Convocatoria.class);
+        return documentRepository.findByNomOriginalAndConvocatoria(nom, convocatoriaEntity)
+                .map(Document::getTraspassat)
+                .orElse(false);
+    }
+
     public DocumentDto getDocumentByIdDriveGoogleDrive(String idDrive, ConvocatoriaDto convocatoria) {
         Convocatoria convocatoriaEntity = modelMapper.map(convocatoria, Convocatoria.class);
         Document document = documentRepository.findByIdDriveGoogleDriveAndConvocatoria(idDrive, convocatoriaEntity).orElse(null);


### PR DESCRIPTION
## Summary
- skip already transferred FEMPO files in the scheduled sync based on the `traspassat` flag and keep document records when tutor folders are purged
- mark transferred items as `traspassat` when persisting metadata and reuse the flag for manual copy operations
- add a helper in `DocumentService` to query the transfer status

## Testing
- `mvn -q -DskipTests package` *(fails: Maven cannot reach Spring repositories from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d65618305c8327bfd729f9a3f86409